### PR TITLE
fix(channel list): channel mention

### DIFF
--- a/apps/bot/src/commands/channel.ts
+++ b/apps/bot/src/commands/channel.ts
@@ -147,12 +147,12 @@ export default async ({ bot }: CommandArgs) => {
 
 		const watchedChannels = channelSettings
 			.filter((channel) => channel.visible)
-			.map((channel) => channel.toString())
+			.map((channel) => `<#${channel.channelId}>`)
 			.join("\n");
 
 		const ignoredChannels = channelSettings
 			.filter((channel) => !channel.visible)
-			.map((channel) => channel.toString())
+			.map((channel) => `<#${channel.channelId}>`)
 			.join("\n");
 
 		embed.addFields([


### PR DESCRIPTION
apparently `channel` does not have a handler for toString so instead we send the channel id in the format of <#ID> which will mention the channel, also showing its name