### PR TITLE
 Ignore stars from before the bot joined the guild

### DIFF
--- a/apps/bot/src/listeners/star.ts
+++ b/apps/bot/src/listeners/star.ts
@@ -215,6 +215,11 @@ export default async ({ bot }: CommandArgs) => {
 			return;
 		}
 
+		// Check to see if the message is from before the bot joined
+		if (targetMessage.createdTimestamp < raw.message.guild!.joinedTimestamp) {
+			return;
+		}
+
 		let postId = null;
 
 		try {


### PR DESCRIPTION
- When checking to post a message to then starboard, the bot checks if the message is from before it joined and stops if so.
- This is to prevent users from clogging up the starboard by starring old messages.